### PR TITLE
fixed missing and extra curly brackets

### DIFF
--- a/Bankey/11-Animating-with-Core-Animation/README.md
+++ b/Bankey/11-Animating-with-Core-Animation/README.md
@@ -152,18 +152,17 @@ And then adding it to our view and doing Auto Layout just like any other control
 
 ```swift
 private func commonInit() {
-        setupShakeyBell()
-    }
+    setupShakeyBell()
+}
     
-    private func setupShakeyBell() {
-        shakeyBellView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(shakeyBellView)
-        
-        NSLayoutConstraint.activate([
-            shakeyBellView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            shakeyBellView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-    }
+private func setupShakeyBell() {
+    shakeyBellView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(shakeyBellView)
+    
+    NSLayoutConstraint.activate([
+        shakeyBellView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        shakeyBellView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
 }
 ```
 

--- a/Bankey/9-NotificationCenter/README.md
+++ b/Bankey/9-NotificationCenter/README.md
@@ -24,6 +24,7 @@ lazy var logoutBarButtonItem: UIBarButtonItem = {
 extension AccountSummaryViewController {
     private func setup() {
         setupNavigationBar()
+    }
 
     func setupNavigationBar() {
         navigationItem.rightBarButtonItem = logoutBarButtonItem


### PR DESCRIPTION
### Description

When following along with this awesome course's notes i found the following issues:

1 - In **NotificationCenter\Adding a logout button** section the setup() method is missing a curly brace.

2 - In **Animating with Core Animation\Add it to the table view header** section there is an extra curly brace.

I fixed those typos so that other students can easily copy and paste it.

### Affected page

https://github.com/jrasmusson/ios-professional-course/blob/main/Bankey/9-NotificationCenter/README.md
https://github.com/jrasmusson/ios-professional-course/blob/main/Bankey/11-Animating-with-Core-Animation/README.md

### Screenshots

**Issue 1**
<img width="1019" alt="Issue_1" src="https://user-images.githubusercontent.com/30513938/152554154-6f7777bf-3ce9-4fec-a208-43f4a496df1f.png">

**Issue 2**
<img width="1026" alt="Issue_2" src="https://user-images.githubusercontent.com/30513938/152553678-59d2cd3b-1fe1-4949-bd54-442c4d77221c.png">
